### PR TITLE
Ignore file-upload meteor-method by ostrio:files

### DIFF
--- a/instrumenting/session.js
+++ b/instrumenting/session.js
@@ -12,7 +12,8 @@ function start(agent, Session) {
           agent.setCustomContext(msg.params || {});
           agent.setUserContext({ id: this.userId || 'Not authorized' });
 
-          if (transaction) {
+          // _FilesCollectionWrite_ is a prefix for meteor-methods used by meteor/ostrio:files. It sends files via DDP to the server. Monitoring it would send the file - byte-serialized - on to the monitoring system.
+          if (transaction && (!msg.method || !msg.method.startsWith('_FilesCollectionWrite_'))) {
             transaction.addLabels({
               params: JSON.stringify(msg.params)
             });


### PR DESCRIPTION
The package `ostrio:files` registers meteor-method calls starting by `_FilesCollectionWrite_` followed by the name of the file-collection. These method-calls are used to upload files to the server. Monitoring these methods (which come in rapidly as we want to upload the file fastest possible) would result in sending the full file in a EJSON encoded way also to the monitoring system.