### PR TITLE
Removed unnecessary span from http-transaction

### DIFF
--- a/instrumenting/http-in.js
+++ b/instrumenting/http-in.js
@@ -8,8 +8,6 @@ function start(agent, WebApp) {
       transaction.setLabel('method', `${req.method}`);
     }
 
-    const span = agent.startSpan(EXECUTION);
-
     res.on('finish', () => {
       let route = req.originalUrl;
       if (req.originalUrl.endsWith(req.url.slice(1)) && req.url.length > 1) {
@@ -25,9 +23,6 @@ function start(agent, WebApp) {
         transaction.setLabel('route', `${route}`);
       }
 
-      if (span) {
-        span.end();
-      }
       if (transaction) {
         transaction.end();
       }


### PR DESCRIPTION
If you read it on the timeline, the span should actually never differ from the execution time of the transation, so to me it's unnecessary to drag it around - just more to process and visualize and without any value.