### PR TITLE
Removed email package from list of dependencies for meteor-elastic-apm

### DIFF
--- a/package.js
+++ b/package.js
@@ -32,7 +32,6 @@ Package.onUse(function(api) {
     'ddp-common',
     'underscore',
     'http',
-    'email',
     'random'
   ]);
 


### PR DESCRIPTION
First of all, looks like email is never used across the project. But what is more important is email blocks proper upgrading of Meteor to 1.11 because accounts-password since version 1.6.2 requires email package with version 2.x.x 
Linked with issue #53 