### PR TITLE
fix: Replace Meteor.default_server with Meteor.server

### DIFF
--- a/__tests__/methodsInstrument.js
+++ b/__tests__/methodsInstrument.js
@@ -27,12 +27,12 @@ test('close transaction with method result', () => {
     }
   });
 
-  Meteor.default_server.method_handlers.method1();
+  Meteor.server.method_handlers.method1();
 
   expect(agent.currentTransaction.end.mock.calls.length).toBe(1);
   expect(agent.currentTransaction.end.mock.calls[0][0]).toBe('success');
 
-  Meteor.default_server.method_handlers.method2();
+  Meteor.server.method_handlers.method2();
 
   expect(agent.currentTransaction.end.mock.calls.length).toBe(2);
   expect(agent.currentTransaction.end.mock.calls[1][0]).toBe('success');
@@ -51,7 +51,7 @@ test('ignore if transaction is undefined', () => {
 
   instrumentMethods(agent, Meteor);
 
-  Meteor.default_server.method_handlers.method1();
+  Meteor.server.method_handlers.method1();
 });
 
 test('close transaction and its span with method result', () => {
@@ -79,7 +79,7 @@ test('close transaction and its span with method result', () => {
     }
   });
 
-  Meteor.default_server.method_handlers.method1();
+  Meteor.server.method_handlers.method1();
 
   expect(agent.currentTransaction.end.mock.calls.length).toBe(1);
   expect(agent.currentTransaction.end.mock.calls[0][0]).toBe('success');
@@ -113,14 +113,14 @@ test('catch meteor method exception', () => {
   });
 
   expect(() => {
-    Meteor.default_server.method_handlers.method1();
+    Meteor.server.method_handlers.method1();
   }).toThrow();
 
   expect(agent.captureError.mock.calls.length).toBe(1);
   expect(agent.captureError.mock.calls[0][0].message).toBe('Test error 1');
 
   expect(() => {
-    Meteor.default_server.method_handlers.method2();
+    Meteor.server.method_handlers.method2();
   }).toThrow();
 
   expect(agent.captureError.mock.calls.length).toBe(2);
@@ -148,7 +148,7 @@ test('transform string exception into Error object', () => {
   instrumentMethods(agent, Meteor);
 
   expect(() => {
-    Meteor.default_server.method_handlers.textError();
+    Meteor.server.method_handlers.textError();
   }).toThrow();
 
   expect(agent.captureError.mock.calls.length).toBe(1);

--- a/__tests__/mocks/meteor.js
+++ b/__tests__/mocks/meteor.js
@@ -15,12 +15,12 @@ function newMeteor() {
     publish: jest.fn(),
     Collection,
     methods(methodsMap) {
-      this.default_server.method_handlers = {
-        ...this.default_server.method_handlers,
+      this.server.method_handlers = {
+        ...this.server.method_handlers,
         ...methodsMap
       };
     },
-    default_server: {
+    server: {
       method_handlers: {}
     }
   };

--- a/instrumenting/methods.js
+++ b/instrumenting/methods.js
@@ -52,7 +52,7 @@ function start(agent, Meteor) {
     });
   }
 
-  const methodHandlers = Meteor.default_server.method_handlers;
+  const methodHandlers = Meteor.server.method_handlers;
   Object.keys(methodHandlers).forEach(methodName => wrapMethods(methodName, methodHandlers));
 
   shimmer.wrap(Meteor, 'methods', function(original) {

--- a/meteorx.js
+++ b/meteorx.js
@@ -11,7 +11,7 @@ function getSession() {
     headers: []
   };
 
-  const server = Meteor.default_server;
+  const server = Meteor.server;
 
   server._handleConnect(fakeSocket, {
     msg: 'connect',


### PR DESCRIPTION
`Meteor.default_server` is undocumented, and was [finally removed in Meteor 2.3](https://github.com/meteor/meteor/commit/b5b7306bedc3e8eb241e64efb1e281925aa75dd3#diff-b0eacacabe2e30c52a4e6144ee4a5e960fd8760ed4ecf2ad3b1bb2f6074a4232L22).

This causes this package to be incompatible with Meteor >2.3.

Note: I'm inexperienced in developing Meteor packages, so I haven't tested that this actually works.

